### PR TITLE
Android expects font name: Roboto_medium

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -16,8 +16,8 @@ import { AuthProvider } from './context/AuthProvider';
 LogBox.ignoreLogs(['Setting a timer']);
 
 const getFonts = () => Font.loadAsync({
-  'roboto-medium': require('../assets/fonts/Roboto-Medium.ttf'),
-  'roboto-bold': require('../assets/fonts/Roboto-Bold.ttf'),
+  'Roboto_medium': require('../assets/fonts/Roboto-Medium.ttf'),
+  'Roboto_bold': require('../assets/fonts/Roboto-Bold.ttf'),
 });
 
 const App = () => {


### PR DESCRIPTION
This removes all font errors when run on Android devices/emulators. My expo logs now look like:
```
Finished building JavaScript bundle in 76ms.
Running application on sdk_gphone_x86.
Connected with Firebase

```